### PR TITLE
import_request_variables is not supported after PHP 5.4.0

### DIFF
--- a/www/inc/runtime.inc.php
+++ b/www/inc/runtime.inc.php
@@ -43,9 +43,8 @@ else {
 require_once('rdf.lib.php');
 
 date_default_timezone_set('America/New_York');
-extract($_GET, EXTR_OVERWRITE && EXTR_PREFIX_ALL, 'i_');
-extract($_POST, EXTR_OVERWRITE && EXTR_PREFIX_ALL, 'i_');
-//import_request_variables('gp', 'i_');
+extract($_GET, EXTR_PREFIX_ALL, 'i');
+extract($_POST, EXTR_PREFIX_ALL, 'i');
 
 # init options
 $_options = new stdClass();


### PR DESCRIPTION
Since PHP 5.4.0 the function `import_request_variables`[1] is no longer supported. I have replaced it by using `extract` [2] instead.

[1] http://php.net/manual/en/function.import-request-variables.php
[2] http://www.php.net/manual/de/function.extract.php
